### PR TITLE
Feat/incorrect success with under5

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -392,22 +392,23 @@ def post_command(message, token, data_user, channel_id, is_replace_plus=False):
     print(res.url)
 
 
-def judge_1d100(target: int, actual: int):
+def judge_1d100(target: int, dice: int):
     """"
     Judge 1d100 dice result, and return text and color for message.
     Result is critical, success, failure or fumble.
     Arguments:
         target {int} -- target value (ex. skill value)
-        actual {int} -- dice value
+        dice {int} -- dice value
     Returns:
         message {string}
         rgb_color {string}
     """
-    if actual <= 5:
-        return "成功", COLOR_CRITICAL
-    elif actual <= target:
+    if dice <= target:
+        if dice <= 5:
+            return "成功", COLOR_CRITICAL
         return "成功", COLOR_SUCCESS
-    elif actual >= 96:
+
+    if dice >= 96:
         return "失敗", COLOR_FUMBLE
     return "失敗", COLOR_FAILURE
 

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -405,11 +405,11 @@ def judge_1d100(target: int, dice: int):
     """
     if dice <= target:
         if dice <= 5:
-            return "成功", COLOR_CRITICAL
+            return "クリティカル", COLOR_CRITICAL
         return "成功", COLOR_SUCCESS
 
     if dice >= 96:
-        return "失敗", COLOR_FUMBLE
+        return "ファンブル", COLOR_FUMBLE
     return "失敗", COLOR_FAILURE
 
 def split_alternative_roll_or_value(cmd) -> Tuple[str, str]:

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -20,14 +20,14 @@ def test_2():
 
 
 @pytest.mark.parametrize("target, actual, exp_msg, exp_color", [
-    (100, 1, "成功", main.COLOR_CRITICAL),
-    (100, 5, "成功", main.COLOR_CRITICAL),
+    (1, 1, "クリティカル", main.COLOR_CRITICAL),
+    (5, 5, "クリティカル", main.COLOR_CRITICAL),
     (20, 15, "成功", main.COLOR_SUCCESS),
-    (1, 5, "失敗", main.COLOR_FAILURE),
     (100, 100, "成功", main.COLOR_SUCCESS),
+    (1, 5, "失敗", main.COLOR_FAILURE),
     (94, 95, "失敗", main.COLOR_FAILURE),
-    (95, 96, "失敗", main.COLOR_FUMBLE),
-    (95, 100, "失敗", main.COLOR_FUMBLE),
+    (95, 96, "ファンブル", main.COLOR_FUMBLE),
+    (95, 100, "ファンブル", main.COLOR_FUMBLE),
 ])
 def test_judge_1d100(target, actual, exp_msg, exp_color):
     msg, color = main.judge_1d100(target, actual)

--- a/tests/test_lambda_function.py
+++ b/tests/test_lambda_function.py
@@ -23,6 +23,7 @@ def test_2():
     (100, 1, "成功", main.COLOR_CRITICAL),
     (100, 5, "成功", main.COLOR_CRITICAL),
     (20, 15, "成功", main.COLOR_SUCCESS),
+    (1, 5, "失敗", main.COLOR_FAILURE),
     (100, 100, "成功", main.COLOR_SUCCESS),
     (94, 95, "失敗", main.COLOR_FAILURE),
     (95, 96, "失敗", main.COLOR_FUMBLE),


### PR DESCRIPTION
- fix #23 : ダイス結果が5以下だと技能値未満でも成功と判定するバグを修正
- ついでに、クリティカルとファンブルはテキストでも明示するように変更