### PR TITLE
hideコマンドを修正

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -838,14 +838,16 @@ def bootstrap(event: dict, _context) -> str:
             param = get_user_params(user_id)
             dict_state = get_dict_state(user_id)
             channel = '@' + dict_state["kp_id"]
+            color_hide = "gray"
 
-            m = re.match(r"HIDE\+(.*?)(\+|\-|\*|\/)?(\d{,})?$", key)
+            m = re.match(r"HIDE\s(.*?)(\+|\-|\*|\/)?(\d{,})?$", key)
             if m is None:
-                post_message = "技能名が解釈できません"
+                text = "role not found"
+                post_message = f"技能名が解釈できません。\n{key}"
             elif m.group(1) and m.group(1) not in param:
+                text = "error"
                 name_role = m.group(1)
                 post_message = "この技能は所持していません"
-                color_hide = "gray"
             else:
                 name_role = m.group(1)
                 n_targ = 0
@@ -878,7 +880,7 @@ def bootstrap(event: dict, _context) -> str:
                 str_result, color_hide = judge_1d100(int(n_targ), num)
                 post_message = f"{str_result} 【{name_role}】 {num}/{n_targ} ({msg_disp}{msg_rev})"
 
-            text = f"<@{user_id}> try {name_role}"
+                text = f"<@{user_id}> try {name_role}"
 
             payload = {
                 'token': token,

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -845,9 +845,9 @@ def bootstrap(event: dict, _context) -> str:
                 text = "role not found"
                 post_message = f"技能名が解釈できません。\n{key}"
             elif m.group(1) and m.group(1) not in param:
-                text = "error"
+                text = "role miss"
                 name_role = m.group(1)
-                post_message = "この技能は所持していません"
+                post_message = f"この技能は所持していません。\n{key}"
             else:
                 name_role = m.group(1)
                 n_targ = 0


### PR DESCRIPTION
https://github.com/cahlchang/CoCNonKP/blob/master/lambda_function.py#L637
ここでunquoteからunquote_plusに変わっていて正規表現文字列の修正が必要だった。
通常lambdaはコマンドの半角スペースを+として解釈するが
unquote_plusではさらに+をスペースに変換する。
もともとは+を期待した正規表現だったため解釈が出来なかった。

（余談）
もともとunquote_plusを使わなかった理由はコマンド上で利用される「+」まで
半角スペースに変更されるケースがあった記憶。（記憶違いかもしれない）
・例
/cc hide 心理学+10
→unquote message
hide+心理学+10
→unquote_plus message
hide 心理学 10

ただ、今確認してみると取りたい文字列で取れている様子。
→current message
hide 心理学+10

どこかで対応してくれたのか、とりあえず良さそうなのでこのままで。